### PR TITLE
Unityバージョンを 2019.3.9f1に変更

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.unity.ide.vscode": "1.1.4",
     "com.unity.multiplayer-hlapi": "1.0.4",
     "com.unity.purchasing": "2.0.6",
-    "com.unity.test-framework": "1.1.9",
+    "com.unity.test-framework": "1.1.13",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.10",
     "com.unity.ugui": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f6
-m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)
+m_EditorVersion: 2019.3.9f1
+m_EditorVersionWithRevision: 2019.3.9f1 (e6e740a1c473)


### PR DESCRIPTION
UnityVer を 2019.3.9f1 に変更
https://unity3d.com/jp/unity/whats-new/2019.3.9

Known Issues が多すぎる...