### PR TITLE
MonoScriptのTemplateテキストファイルにusing UnityEngine を追加

### DIFF
--- a/Assets/ScriptTemplates/MonoClass.txt
+++ b/Assets/ScriptTemplates/MonoClass.txt
@@ -5,6 +5,8 @@
 // Created by #AUTHOR# on #DATA#
 // 
 
+using UnityEngine;
+
 namespace #NAMESPACE#
 {
 	/// <summary>


### PR DESCRIPTION
そもそも MonoBehaviourがUnityEngineのusing定義が必要なので消しちゃだめだった。
追加。

`using System;`

もデフォルトにするか迷ってるけど一旦はなし