### PR TITLE
SortOrderChangerの設定ファイルをEditorの時はローカルファイルを読み出すように改修

### DIFF
--- a/Assets/App/Scripts/Utility/Editor/Attribute/SortOrderValueAttributeDrawer.cs
+++ b/Assets/App/Scripts/Utility/Editor/Attribute/SortOrderValueAttributeDrawer.cs
@@ -67,7 +67,6 @@ namespace Ling.Utility.Editor.Attribute
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			Utility.Editor.AssetBundle.AddressableHelper.LoadAsset<GameObject>("");
 			var names = Names;
 			if (names.IsNullOrEmpty()) 
 			{

--- a/Assets/App/Scripts/Utility/UI/SortOrderChanger.cs
+++ b/Assets/App/Scripts/Utility/UI/SortOrderChanger.cs
@@ -59,11 +59,7 @@ namespace Ling.Utility.UI
 
 		private void OnSortOrderNameChanged()
 		{
-			// 起動時のみ値を変化させる
-			if (Application.isPlaying)
-			{
-				Apply();
-			}
+			Apply();
 		}
 
 		private void Apply()

--- a/Assets/App/Scripts/Utility/UI/SortOrderSettings.cs
+++ b/Assets/App/Scripts/Utility/UI/SortOrderSettings.cs
@@ -20,7 +20,7 @@ namespace Ling.Utility.UI
 	{
 		#region 定数, class, enum
 
-		public const string Address = "UI_SortOrderSettings";
+		public const string Address = "SortOrderSettings";
 
 		[System.Serializable]
 		public class ValueData
@@ -59,7 +59,7 @@ namespace Ling.Utility.UI
 				// Editorモードのときはローカルファイルを読み込む
 				if (settings == null)
 				{
-					settings = Utility.AssetBundle.AddressableHelper.LoadAsset<SortOrderSettings>(address: Address);
+					settings = AddressableHelper.LoadAsset<SortOrderSettings>(address: Address);
 				}
 #endif
 


### PR DESCRIPTION
AddressableAssetDataを使用時、設定ファイルをアセットバンドル対象としてもEditor操作時にはローカルファイルを読み出すように処理を改修