### PR TITLE
スキル発動処理

### DIFF
--- a/Assets/App/Scripts/Common/Item/ItemEntity.cs
+++ b/Assets/App/Scripts/Common/Item/ItemEntity.cs
@@ -9,6 +9,7 @@ using System;
 using UnityEngine;
 using Zenject;
 using Ling.MasterData.Item;
+using Ling.MasterData.Skill;
 
 namespace Ling.Common.Item
 {
@@ -58,6 +59,8 @@ namespace Ling.Common.Item
 				return _master;
 			}
 		}
+
+		public SkillMaster Skill => Master?.Skill;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Item/FoodMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Item/FoodMaster.cs
@@ -31,11 +31,8 @@ namespace Ling.MasterData.Item
 		[SerializeField, FieldName("種類")]
 		private Const.Item.Food _type = default;
 
-		[SerializeField, FieldName("スタミナ回復量")]
-		private int _staminaValue = 0;
-
-		[SerializeField, FieldName("HP回復量")]
-		private int _hpValue = 0;
+		[SerializeField]
+		private Skill.SkillMaster _skill = default;
 
 		#endregion
 
@@ -48,8 +45,6 @@ namespace Ling.MasterData.Item
 		public override Const.Item.Category Category => Const.Item.Category.Food;
 
 		public Const.Item.Food Type => _type;
-		public int StaminaValue => _staminaValue;
-		public int HPValue => _hpValue;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Item/FoodMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Item/FoodMaster.cs
@@ -31,9 +31,6 @@ namespace Ling.MasterData.Item
 		[SerializeField, FieldName("種類")]
 		private Const.Item.Food _type = default;
 
-		[SerializeField]
-		private Skill.SkillMaster _skill = default;
-
 		#endregion
 
 

--- a/Assets/App/Scripts/Common/MasterData/Item/ItemMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Item/ItemMaster.cs
@@ -34,6 +34,9 @@ namespace Ling.MasterData.Item
 		[SerializeField, FieldName("名前")]
 		private string _name = default;
 
+		[SerializeField]
+		private Skill.SkillMaster _skill = default;
+
 		#endregion
 
 
@@ -48,6 +51,11 @@ namespace Ling.MasterData.Item
 		/// アイテムカテゴリ
 		/// </summary>
 		public abstract Const.Item.Category Category { get; }
+
+		/// <summary>
+		/// スキル
+		/// </summary>
+		public Skill.SkillMaster Skill => _skill;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Skill.meta
+++ b/Assets/App/Scripts/Common/MasterData/Skill.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f99cefef42a964c85afcdaa0dfdbd1e1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillActionEntity.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillActionEntity.cs
@@ -1,0 +1,62 @@
+﻿//
+// SkillActionData.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+using UnityEngine;
+using Utility.MasterData;
+using Utility.Attribute;
+using System.Collections.Generic;
+
+
+namespace Ling.MasterData.Skill
+{
+	/// <summary>
+	/// 一つのアクションデータ
+	/// </summary>
+	[System.Serializable]
+	public class SkillActionEntity
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField]
+		private SkillHealEntity _heal = default;
+
+		[SerializeField]
+		private SkillDamageEntity _damage = default;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillActionEntity.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillActionEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97d409e4e55a740019ddd89f76b3e0e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillDamageEntity.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillDamageEntity.cs
@@ -1,0 +1,57 @@
+﻿//
+// SkillDamageEntity.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+using UnityEngine;
+using Utility.Attribute;
+using Sirenix.OdinInspector;
+
+namespace Ling.MasterData.Skill
+{
+	/// <summary>
+	/// よくあるダメージ
+	/// </summary>
+	[System.Serializable, InlineProperty]
+	public class SkillDamageEntity
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField, FieldName("威力")]
+		private int _power;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillDamageEntity.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillDamageEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce0ddebd738a84a1786fd8ee8098c233
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs
@@ -1,0 +1,60 @@
+﻿//
+// SkillHealEntity.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+using UnityEngine;
+using Utility.Attribute;
+using Sirenix.OdinInspector;
+
+namespace Ling.MasterData.Skill
+{
+	/// <summary>
+	/// 回復
+	/// </summary>
+	[System.Serializable, InlineProperty]
+	public class SkillHealEntity
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField, FieldName("HP")]
+		private int _hp = default;
+
+		[SerializeField, FieldName("スタミナ")]
+		private int _stamina = default;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs
@@ -30,15 +30,18 @@ namespace Ling.MasterData.Skill
 		#region private 変数
 
 		[SerializeField, FieldName("HP")]
-		private int _hp = default;
+		private long _hp = default;
 
 		[SerializeField, FieldName("スタミナ")]
-		private int _stamina = default;
+		private long _stamina = default;
 
 		#endregion
 
 
 		#region プロパティ
+
+		public long HP => _hp;
+		public long Stamina => _stamina;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillHealEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cf110e7d822d4291a870218a2587431
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs
@@ -67,6 +67,9 @@ namespace Ling.MasterData.Skill
 
 		#region public, protected 関数
 
+		public SkillHealEntity Heal => _enableHeal ? _heal : null;
+		public SkillDamageEntity Damage => _enableDamage ? _damage : null;
+
 		#endregion
 
 

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs
@@ -1,0 +1,77 @@
+﻿//
+// SkillMaster.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+using UnityEngine;
+using Utility.MasterData;
+using Utility.Attribute;
+using System.Collections.Generic;
+using Sirenix.OdinInspector;
+
+namespace Ling.MasterData.Skill
+{
+	/// <summary>
+	/// スキル情報マスタ
+	/// </summary>
+	[System.Serializable]
+	public class SkillMaster
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField, FieldName("詠唱演出ファイル名")]
+		private string _filename = default;
+
+		[SerializeField, FieldName("ヒット回数(最小)")]
+		private int _hitMin = 1;
+
+		[SerializeField, FieldName("ヒット回数(最大)")]
+		private int _hitMax = 1;
+
+		[SerializeField, FieldName("回復")]
+		private bool _enableHeal = false;
+
+		[SerializeField, HideLabel, ShowIf("_enableHeal")]
+		private SkillHealEntity _heal = default;
+
+		[SerializeField, FieldName("ダメージ")]
+		private bool _enableDamage = false;
+
+		[SerializeField, HideLabel, ShowIf("_enableDamage")]
+		private SkillDamageEntity _damage = default;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Skill/SkillMaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bd17cadfe0014bc4b12c47d0d0cb635
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Map/Chara/CharaControl.cs
+++ b/Assets/App/Scripts/Map/Chara/CharaControl.cs
@@ -270,7 +270,7 @@ namespace Ling.Chara
 				// 終了時、移動プロセスリストから削除する
 				process.AddAllFinishAction(action_ =>
 					{
-						_moveProcesses.Remove(action_);
+						_moveProcesses.Remove(process);
 					});
 
 				process.SetEnable(true);

--- a/Assets/App/Scripts/Map/Chara/CharaControl.cs
+++ b/Assets/App/Scripts/Map/Chara/CharaControl.cs
@@ -287,7 +287,7 @@ namespace Ling.Chara
 				// 終了時、攻撃プロセスリストから削除する
 				process.AddAllFinishAction(action_ =>
 					{
-						_attackProcess.Remove(action_);
+						_attackProcess.Remove(process);
 					});
 
 				process.SetEnable(true);

--- a/Assets/App/Scripts/Map/Chara/CharaEvents.cs
+++ b/Assets/App/Scripts/Map/Chara/CharaEvents.cs
@@ -71,4 +71,13 @@ namespace Ling.Chara
 		public ICharaController Chara;
 		public int Lv;
 	}
+
+	/// <summary>
+	/// HP回復
+	/// </summary>
+	public class EventHealHP
+	{
+		public ICharaController Chara;
+		public long Value;
+	}
 }

--- a/Assets/App/Scripts/Scenes/Battle/BattleConst.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleConst.cs
@@ -61,6 +61,7 @@ namespace Ling.Scenes.Battle
 
 	public enum ProcessType
 	{
+		PlayerSkill,	// プレイヤースキル
 		Action,		// キャラの行動
 		Exp,		// 経験値加算処理
 		Reaction,	// 攻撃を受けた後などのリアクション

--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -47,6 +47,7 @@ namespace Ling.Scenes.Battle
 		CharaProcessEnd,
 		NextStage,
 		Adv,
+		UseItem,
 	}
 
 	/// <summary>
@@ -165,6 +166,7 @@ namespace Ling.Scenes.Battle
 			RegistPhase<BattlePhaseReaction>(Phase.Reaction);
 			RegistPhase<BattlePhaseExp>(Phase.Exp);
 			RegistPhase<BattlePhaseCharaMove>(Phase.Move);
+			RegistPhase<BattlePhaseUseItem>(Phase.UseItem);
 
 			ProcessContainer.Setup(_processManager, gameObject);
 
@@ -245,9 +247,16 @@ namespace Ling.Scenes.Battle
 			{
 				case SceneID.Menu:
 					// なにか使用したか
-
-					// 何も使用してないならプレイヤー行動に戻す
-					_phase.ChangePhase(Phase.PlayerAction);
+					if (result.UseItemEntity == null)
+					{
+						// 何も使用してないならプレイヤー行動に戻す
+						_phase.ChangePhase(Phase.PlayerAction);
+					}
+					else
+					{
+						var useItemArg = new BattlePhaseUseItem.Arg { Item = result.UseItemEntity };
+						_phase.ChangePhase(Phase.UseItem, useItemArg);
+					}
 					break;
 			}
 		}

--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -35,6 +35,7 @@ namespace Ling.Scenes.Battle
 		PlayerAttack,
 		PlayerActionProcess,
 		PlayerActionEnd,
+		PlayerSkill,
 
 		// Enemy
 		EnemyAction,
@@ -157,6 +158,7 @@ namespace Ling.Scenes.Battle
 			RegistPhase<BattlePhasePlayerAttack>(Phase.PlayerAttack);
 			RegistPhase<BattlePhasePlayerActionProcess>(Phase.PlayerActionProcess);
 			RegistPhase<BattlePhasePlayerActionEnd>(Phase.PlayerActionEnd);
+			RegistPhase<BattlePhasePlayerSkill>(Phase.PlayerSkill);
 
 			RegistPhase<BattlePhaseAdv>(Phase.Adv);
 			RegistPhase<BattlePhaseNextStage>(Phase.NextStage);
@@ -247,7 +249,7 @@ namespace Ling.Scenes.Battle
 			{
 				case SceneID.Menu:
 					// なにか使用したか
-					if (result.UseItemEntity == null)
+					if (result?.UseItemEntity == null)
 					{
 						// 何も使用してないならプレイヤー行動に戻す
 						_phase.ChangePhase(Phase.PlayerAction);

--- a/Assets/App/Scripts/Scenes/Battle/Message/MessageConverter.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Message/MessageConverter.cs
@@ -84,6 +84,12 @@ namespace Ling.Scenes.Battle.Message
 					// レベルアップ
 					ShowMessage($"<color=#ffa500ff>{ev.Chara.Name} は レベルが{ev.Lv}になった</color>");
 				});
+
+			_eventManager.Add<Chara.EventHealHP>(this, ev => 
+				{
+					// HP回復
+					ShowMessage($"<color=#90ee90>{ev.Chara.Name} は HP{ev.Value}回復した</Color>");
+				});
 		}
 
 		private  void OnDestroy()

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEnemyThink.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEnemyThink.cs
@@ -110,7 +110,8 @@ namespace Ling.Scenes.Battle.Phases
 						if (enemy.ExistsAttackProcess)
 						{
 							var process = new Process.ProcessCharaAction(enemy);
-							Scene.ProcessContainer.Add(ProcessType.Action, process);						}
+							Scene.ProcessContainer.Add(ProcessType.Action, process);
+						}
 					}
 				}
 

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerSkill.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerSkill.cs
@@ -1,0 +1,72 @@
+﻿//
+// BattlePhasePlayerSkill.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.04
+//
+
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using Utility.Extensions;
+using Zenject;
+using System.Threading;
+
+namespace Ling.Scenes.Battle.Phases
+{
+	/// <summary>
+	/// プレイヤー側のスキル実行
+	/// </summary>
+	public class BattlePhasePlayerSkill : BattlePhaseBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public override void PhaseStart()
+		{
+			// なにもないときは終了する
+			if (!Scene.ProcessContainer.Exists(ProcessType.PlayerSkill))
+			{
+				Change(Phase.EnemyTink);
+				return;
+			}
+		}
+
+		public override async UniTask PhaseStartAsync(CancellationToken token)
+		{
+			await Scene.ProcessContainer.UniTaskExecuteOnceAsync(ProcessType.PlayerSkill, token: token);
+
+			Change(Phase.EnemyTink);
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerSkill.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerSkill.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bed9830247fdb4de1a363ffe41217935
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
@@ -56,12 +56,8 @@ namespace Ling.Scenes.Battle.Phases
 			// アイテムによって処理を変更する
 			var arg = Argument as Arg;
 
-			switch (arg.Item.Category)
-			{
-				// 食べ物
-				case Const.Item.Category.Food:
-					break;
-			}
+			// スキル
+			var skill = arg.Item.Skill;
 		}
 
 		/// <summary>

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
@@ -1,0 +1,90 @@
+﻿//
+// BattlePhaseUseItem.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+using UnityEngine;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using System.Threading;
+using Zenject;
+using Utility.Extensions;
+
+namespace Ling.Scenes.Battle.Phases
+{
+	/// <summary>
+	/// アイテムを使用した
+	/// </summary>
+	public class BattlePhaseUseItem : BattlePhaseBase
+	{
+		#region 定数, class, enum
+
+		public class Arg : Utility.PhaseArgument
+		{
+			public Common.Item.ItemEntity Item;
+		}
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public override void PhaseStart()
+		{
+			// アイテムによって処理を変更する
+			var arg = Argument as Arg;
+
+			switch (arg.Item.Category)
+			{
+				// 食べ物
+				case Const.Item.Category.Food:
+					break;
+			}
+		}
+
+		/// <summary>
+		/// 非同期
+		/// </summary>
+		public override async UniTask PhaseStartAsync(CancellationToken token)
+		{
+			await Scene.ProcessContainer.ExecuteAsync(ProcessType.Reaction, token);
+		}
+
+		public override void PhaseUpdate()
+		{
+		}
+
+		public override void PhaseStop()
+		{
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs
@@ -36,6 +36,8 @@ namespace Ling.Scenes.Battle.Phases
 
 		#region private 変数
 
+		[Inject] private Chara.CharaManager _charaManager = default;
+
 		#endregion
 
 
@@ -58,14 +60,15 @@ namespace Ling.Scenes.Battle.Phases
 
 			// スキル
 			var skill = arg.Item.Skill;
-		}
+			var player = _charaManager.Player;
+			var skillProcess = player.AddAttackProcess<Skill.SkillProcess>();
+			skillProcess.Setup(player, skill);
 
-		/// <summary>
-		/// 非同期
-		/// </summary>
-		public override async UniTask PhaseStartAsync(CancellationToken token)
-		{
-			await Scene.ProcessContainer.ExecuteAsync(ProcessType.Reaction, token);
+			// キャラアクションに移動する
+			var process = new Process.ProcessCharaAction(player);
+			Scene.ProcessContainer.Add(ProcessType.PlayerSkill, process);
+
+			Change(Phase.PlayerSkill);
 		}
 
 		public override void PhaseUpdate()

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseUseItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ac61f6b29af9474bb66183c95c9b1f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Battle/Process/ProcessSkill.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Process/ProcessSkill.cs
@@ -8,9 +8,9 @@
 namespace Ling.Scenes.Battle.Process
 {
 	/// <summary>
-	/// 
+	/// スキル実行プロセス
 	/// </summary>
-	public class ProcessUseFoodItem : Utility.ProcessBase
+	public class ProcessSkill: Utility.ProcessBase
 	{
 		#region 定数, class, enum
 
@@ -38,6 +38,11 @@ namespace Ling.Scenes.Battle.Process
 
 
 		#region public, protected 関数
+
+		protected override void ProcessStartInternal()
+		{
+			// スキル内容によってプロセスを後ろにつけ合わす
+		}
 
 		#endregion
 

--- a/Assets/App/Scripts/Scenes/Battle/Process/ProcessSkill.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Process/ProcessSkill.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 807f6835e013e4a77bb8049f29db0ae9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Battle/Process/ProcessUseFoodItem.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Process/ProcessUseFoodItem.cs
@@ -1,0 +1,49 @@
+﻿//
+// ProcessUseFoodItem.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+namespace Ling.Scenes.Battle.Process
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class ProcessUseFoodItem : Utility.ProcessBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Process/ProcessUseFoodItem.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Process/ProcessUseFoodItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6ba29fad837f4cff8a76c0f806c02bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Battle/Skill.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Skill.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64ea031e7c5f9477bbe5685e8aef289b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs
@@ -6,6 +6,7 @@
 //
 
 using Ling.MasterData.Skill;
+using Zenject;
 
 namespace Ling.Scenes.Battle.Skill
 {
@@ -25,6 +26,8 @@ namespace Ling.Scenes.Battle.Skill
 
 
 		#region private 変数
+
+		[Inject] private Utility.IEventManager _eventManager;
 
 		private Chara.ICharaController _chara;
 		private SkillHealEntity _entity;
@@ -53,6 +56,10 @@ namespace Ling.Scenes.Battle.Skill
 		protected override void ProcessStartInternal()
 		{
 			_chara.Status.HP.AddCurrent(_entity.HP);
+
+			// 回復イベント
+			_eventManager.Trigger(new Chara.EventHealHP { Chara = _chara, Value = _entity.HP });
+
 			ProcessFinish();
 		}
 

--- a/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs
@@ -1,0 +1,66 @@
+﻿//
+// HealSkillPorcess.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.04
+//
+
+using Ling.MasterData.Skill;
+
+namespace Ling.Scenes.Battle.Skill
+{
+	/// <summary>
+	/// 回復スキル
+	/// </summary>
+	public class HealSkillProcess : Utility.ProcessBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		private Chara.ICharaController _chara;
+		private SkillHealEntity _entity;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		public void Setup(Chara.ICharaController chara, SkillHealEntity entity)
+		{
+			_chara = chara;
+			_entity = entity;
+		}
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		protected override void ProcessStartInternal()
+		{
+			_chara.Status.HP.AddCurrent(_entity.HP);
+			ProcessFinish();
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/HealSkillProcess.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c6ba29fad837f4cff8a76c0f806c02bc
+guid: c16e29082e8174c69a40f0edf3002394
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
@@ -5,6 +5,8 @@
 // Created by toshiki sakamoto on 2021.05.03
 //
 
+using Ling.MasterData.Skill;
+
 namespace Ling.Scenes.Battle.Skill
 {
 	/// <summary>
@@ -41,6 +43,9 @@ namespace Ling.Scenes.Battle.Skill
 
 		#region private 変数
 
+		private Chara.ICharaController _chara;
+		private SkillMaster _skill;
+
 		#endregion
 
 
@@ -56,15 +61,37 @@ namespace Ling.Scenes.Battle.Skill
 
 		#region public, protected 関数
 
-		public void Setup(string effectName)
+		public void Setup(Chara.ICharaController chara, SkillMaster skill)
 		{
+			_chara = chara;
+			_skill = skill;
+		}
 
+		protected override void ProcessStartInternal()
+		{
+			AttachProcess();
+
+			ProcessFinish();
 		}
 
 		#endregion
 
 
 		#region private 関数
+
+		private void AttachProcess()
+		{
+			// スキル内容によってプロセスを後ろにつけ合わす
+			if (_skill.Heal != null)
+			{
+				SetNext<HealSkillProcess>().Setup(_chara, _skill.Heal);
+			}
+
+			if (_skill.Damage != null)
+			{
+
+			}
+		}
 
 		#endregion
 	}

--- a/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
@@ -1,0 +1,71 @@
+﻿//
+// SkillProcess.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.03
+//
+
+namespace Ling.Scenes.Battle.Skill
+{
+	/// <summary>
+	/// スキル効果プロセス
+	/// 一つの効果のみを表す。もし複数に効果がある場合はこのプロセスがその回数分生成されるようにする
+	/// 複数のプロセスに対する制御は別の担当
+	/// </summary>
+	public class SkillProcess : Utility.ProcessBase
+	{
+		#region 定数, class, enum
+
+		public class Data
+		{
+			public string EffectName;	// 演出名
+
+			// 回復系
+			public HealData HealData;
+
+			// ダメージ系
+		}
+
+		public class HealData
+		{
+			public int HP;	// HP回復値
+		}
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public void Setup(string effectName)
+		{
+
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs
@@ -6,6 +6,8 @@
 //
 
 using Ling.MasterData.Skill;
+using Cysharp.Threading.Tasks;
+using System.Threading;
 
 namespace Ling.Scenes.Battle.Skill
 {
@@ -17,21 +19,6 @@ namespace Ling.Scenes.Battle.Skill
 	public class SkillProcess : Utility.ProcessBase
 	{
 		#region 定数, class, enum
-
-		public class Data
-		{
-			public string EffectName;	// 演出名
-
-			// 回復系
-			public HealData HealData;
-
-			// ダメージ系
-		}
-
-		public class HealData
-		{
-			public int HP;	// HP回復値
-		}
 
 		#endregion
 
@@ -70,6 +57,14 @@ namespace Ling.Scenes.Battle.Skill
 		protected override void ProcessStartInternal()
 		{
 			AttachProcess();
+
+			Execute().Forget();
+		}
+
+		public async UniTask Execute()
+		{
+			// 演出開始
+			await UniTask.Delay(100); // todo: ちょっとまつだけ
 
 			ProcessFinish();
 		}

--- a/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Skill/SkillProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54bd3de4dff144bc8b254950a79f9137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Utility/Process/ProcessBase.cs
+++ b/Assets/App/Scripts/Utility/Process/ProcessBase.cs
@@ -139,7 +139,7 @@ namespace Utility
 			{
 				Next.AddAllFinishAction(_onAllFinish);
 				Next.SetEnable(true);
-				Next.ProcessStart();
+//				Next.ProcessStart();
 			}
 			else
 			{

--- a/Assets/AssetBundles/MasterData/Item/Food/OnigiriMaster.asset
+++ b/Assets/AssetBundles/MasterData/Item/Food/OnigiriMaster.asset
@@ -15,5 +15,14 @@ MonoBehaviour:
   _id: 1
   _name: "\u304A\u306B\u304E\u308A"
   _type: 0
-  _staminaValue: 20
-  _hpValue: 0
+  _skill:
+    _filename: 
+    _hitMin: 1
+    _hitMax: 1
+    _enableHeal: 1
+    _heal:
+      _hp: 2
+      _stamina: 20
+    _enableDamage: 0
+    _damage:
+      _power: 0


### PR DESCRIPTION
# 仮！！！！！

仮コードももりもり... 形にするだけしてみた。
リファクタリングはやる(本気)


変に敵と共通化するより、プレイヤー専用のスキル発動Phaseを作るほうが自由度も高く処理が負いやすくなりそうなのでそうした。
スキルはマスタのデータとして作成し、スキルマスタ全てに回復やダメージなどの設定値をもたせ、有効/無効でスイッチできるように。
アイテムマスタ自体にもスキル効果をもたせることでアイテムによる効果も一発で確認できる形にした