### PR TITLE
メニューにアイテム一覧とは別に装備一覧を出す

### DIFF
--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -81,6 +81,8 @@ MonoBehaviour:
     - ItemFoodMaster
     - StageFirstStageMaster
     - PlayerLvTableMaster
+    - WeaponMaster
+    - ShieldMaster
   m_SchemaTemplates: []
   m_GroupTemplateObjects:
   - {fileID: 11400000, guid: eb803257c556840628782c461fe889eb, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/MasterData.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/MasterData.asset
@@ -22,47 +22,47 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - EnemyMaster
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: 1b56101065b2a5b4a9d7eeb629880611, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 1b56101065b2a5b4a9d7eeb629880611, type: 3}
   - m_GUID: f11f0a207f73e458a825648324c9bfa7
     m_Address: Item
     m_ReadOnly: 0
     m_SerializedLabels: []
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: f11f0a207f73e458a825648324c9bfa7, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: f11f0a207f73e458a825648324c9bfa7, type: 3}
   - m_GUID: d5032237ebcf30d4a8bf0c6190ffd355
     m_Address: Stage
     m_ReadOnly: 0
     m_SerializedLabels:
     - StageMaster
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: d5032237ebcf30d4a8bf0c6190ffd355, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: d5032237ebcf30d4a8bf0c6190ffd355, type: 3}
   - m_GUID: 424c34e44b33e48dbb662dc96edf7b2e
     m_Address: Item/Book
     m_ReadOnly: 0
     m_SerializedLabels:
     - ItemBookMaster
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: 424c34e44b33e48dbb662dc96edf7b2e, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 424c34e44b33e48dbb662dc96edf7b2e, type: 3}
   - m_GUID: 41b22da1f7d714429b22c7b39f3a9e78
     m_Address: Item/Food
     m_ReadOnly: 0
     m_SerializedLabels:
     - ItemFoodMaster
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: 41b22da1f7d714429b22c7b39f3a9e78, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 41b22da1f7d714429b22c7b39f3a9e78, type: 3}
   - m_GUID: 36cb00024ce40c841ac7b14ebd422b62
     m_Address: Stage/FirstStage
     m_ReadOnly: 0
     m_SerializedLabels: []
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: 36cb00024ce40c841ac7b14ebd422b62, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 36cb00024ce40c841ac7b14ebd422b62, type: 3}
   - m_GUID: 562a5e0ee175a4c478524c5a91c04ae1
     m_Address: ConstMaster
     m_ReadOnly: 0
     m_SerializedLabels: []
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 11400000, guid: 562a5e0ee175a4c478524c5a91c04ae1, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 562a5e0ee175a4c478524c5a91c04ae1, type: 2}
   - m_GUID: b0b6b182dcae54110b83e10f4a646292
     m_Address: Player
     m_ReadOnly: 0
@@ -70,6 +70,26 @@ MonoBehaviour:
     - PlayerLvTableMaster
     m_MainAsset: {fileID: 102900000, guid: b0b6b182dcae54110b83e10f4a646292, type: 3}
     m_TargetAsset: {fileID: 102900000, guid: b0b6b182dcae54110b83e10f4a646292, type: 3}
+  - m_GUID: 492f53155458646569f61de3386ed21d
+    m_Address: Equipment
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    m_MainAsset: {fileID: 102900000, guid: 492f53155458646569f61de3386ed21d, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 492f53155458646569f61de3386ed21d, type: 3}
+  - m_GUID: f48942022755c428cb4e394de2e5e915
+    m_Address: Equipment/Weapon
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - WeaponMaster
+    m_MainAsset: {fileID: 102900000, guid: f48942022755c428cb4e394de2e5e915, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: f48942022755c428cb4e394de2e5e915, type: 3}
+  - m_GUID: b7871491884b04e128f59ba8dbe109a4
+    m_Address: Equipment/Shield
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - ShieldMaster
+    m_MainAsset: {fileID: 102900000, guid: b7871491884b04e128f59ba8dbe109a4, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: b7871491884b04e128f59ba8dbe109a4, type: 3}
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: aef05b59aef0747229b6ec62513fbdd8, type: 2}
   m_SchemaSet:

--- a/Assets/App/Resources/Prefabs/Menu/BagMenuControl.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/BagMenuControl.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6623540542039002393}
-  - component: {fileID: 7405478066656933632}
+  - component: {fileID: 384646472144051875}
   m_Layer: 5
   m_Name: BagMenuControl
   m_TagString: Untagged
@@ -37,7 +37,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &7405478066656933632
+--- !u!114 &384646472144051875
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 797401048878199540, guid: fc3620a610a844d6895d12ef2da1e187,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7624282499312169060, guid: fc3620a610a844d6895d12ef2da1e187,
         type: 3}

--- a/Assets/App/Resources/Prefabs/Menu/EquipList.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/EquipList.prefab
@@ -1,0 +1,656 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1276298775960088654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298775960088655}
+  - component: {fileID: 1276298775960088650}
+  - component: {fileID: 1276298775960088649}
+  - component: {fileID: 1276298775960088648}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1276298775960088655
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298775960088654}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1276298776076869886}
+  m_Father: {fileID: 1276298777196705988}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -17, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1276298775960088650
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298775960088654}
+  m_CullTransparentMesh: 1
+--- !u!114 &1276298775960088649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298775960088654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1276298775960088648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298775960088654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &1276298776076869885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298776076869886}
+  - component: {fileID: 1276298776076869887}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1276298776076869886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776076869885}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5538985958177478138}
+  m_Father: {fileID: 1276298775960088655}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -551, y: -936}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1276298776076869887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776076869885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!1 &1276298776152646288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298776152646289}
+  - component: {fileID: 1276298776152646291}
+  - component: {fileID: 1276298776152646290}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1276298776152646289
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776152646288}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1276298776973585180}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1276298776152646291
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776152646288}
+  m_CullTransparentMesh: 1
+--- !u!114 &1276298776152646290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776152646288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1276298776973585171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298776973585180}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1276298776973585180
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298776973585171}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1276298776152646289}
+  m_Father: {fileID: 1276298777033241224}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1276298777033241231
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298777033241224}
+  - component: {fileID: 1276298777033241227}
+  - component: {fileID: 1276298777033241226}
+  - component: {fileID: 1276298777033241225}
+  m_Layer: 5
+  m_Name: Scrollbar Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1276298777033241224
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777033241231}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1276298776973585180}
+  m_Father: {fileID: 1276298777196705988}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: -17}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &1276298777033241227
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777033241231}
+  m_CullTransparentMesh: 1
+--- !u!114 &1276298777033241226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777033241231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1276298777033241225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777033241231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1276298776152646290}
+  m_HandleRect: {fileID: 1276298776152646289}
+  m_Direction: 2
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1276298777196706043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276298777196705988}
+  - component: {fileID: 1276298777196705991}
+  - component: {fileID: 1276298777196705990}
+  - component: {fileID: 1276298777196705989}
+  - component: {fileID: 1276298777196705984}
+  - component: {fileID: 628053437819968976}
+  m_Layer: 5
+  m_Name: EquipList
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1276298777196705988
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1276298775960088655}
+  - {fileID: 1276298777033241224}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1276298777196705991
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_CullTransparentMesh: 1
+--- !u!114 &1276298777196705990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1276298777196705989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 1276298776076869886}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 1276298775960088655}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 1276298777033241225}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1276298777196705984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec496da875a08ef4494893ec042f8889, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _padding:
+    top: 0
+    right: 0
+    bottom: 0
+    left: 0
+  _spacing: 0
+  _direction: 0
+  _instantateItemCount: 4
+  _autoInitItemInstantiate: 1
+--- !u!114 &628053437819968976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276298777196706043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7884d1128ffce413c8701c5cb91119d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scrollView: {fileID: 1276298777196705984}
+  _itemObject: {fileID: 5538985958177478137}
+--- !u!1001 &263760103395184823
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1276298776076869886}
+    m_Modifications:
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Name
+      value: MenuEquipView
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 578531183ce034498acce8f07c24c064, type: 3}
+--- !u!1 &5538985958177478137 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
+    type: 3}
+  m_PrefabInstance: {fileID: 263760103395184823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5538985958177478138 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+    type: 3}
+  m_PrefabInstance: {fileID: 263760103395184823}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/App/Resources/Prefabs/Menu/EquipList.prefab.meta
+++ b/Assets/App/Resources/Prefabs/Menu/EquipList.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95683f48f62a545de9538bb0d1cdfbf2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
@@ -61,7 +61,7 @@ PrefabInstance:
         type: 3}
       propertyPath: _itemObject
       value: 
-      objectReference: {fileID: 2022546281581388950}
+      objectReference: {fileID: 7859694166149296445}
     - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
         type: 3}
       propertyPath: m_Pivot.x
@@ -175,7 +175,7 @@ PrefabInstance:
     - target: {fileID: 5538985958177478138, guid: 95683f48f62a545de9538bb0d1cdfbf2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 95683f48f62a545de9538bb0d1cdfbf2, type: 3}
@@ -197,134 +197,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7884d1128ffce413c8701c5cb91119d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3493388873492431930 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1276298776076869886, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+--- !u!1 &7859694166149296445 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5538985958177478137, guid: 95683f48f62a545de9538bb0d1cdfbf2,
     type: 3}
   m_PrefabInstance: {fileID: 2435691288566326468}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &6009764720124617176
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 3493388873492431930}
-    m_Modifications:
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
-        type: 3}
-      propertyPath: m_Name
-      value: MenuEquipView
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 578531183ce034498acce8f07c24c064, type: 3}
---- !u!1 &2022546281581388950 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
-    type: 3}
-  m_PrefabInstance: {fileID: 6009764720124617176}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
@@ -62,6 +62,16 @@ PrefabInstance:
       propertyPath: _itemObject
       value: 
       objectReference: {fileID: 7859694166149296445}
+    - target: {fileID: 1276298776076869886, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298776076869887, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_HorizontalFit
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
         type: 3}
       propertyPath: m_Pivot.x
@@ -172,6 +182,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: EquipList
       objectReference: {fileID: 0}
+    - target: {fileID: 3718075108212415255, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: _buttonText
+      value: 
+      objectReference: {fileID: 6411268470282333122}
     - target: {fileID: 5538985958177478138, guid: 95683f48f62a545de9538bb0d1cdfbf2,
         type: 3}
       propertyPath: m_RootOrder
@@ -203,3 +218,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 2435691288566326468}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6411268470282333122 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8733665942729740038, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2435691288566326468}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab
@@ -1,0 +1,330 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &428726044966636739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6211493806772389741}
+  - component: {fileID: 5304713615719178957}
+  m_Layer: 5
+  m_Name: EquipMenuControl
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6211493806772389741
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428726044966636739}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3493388872632589312}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5304713615719178957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428726044966636739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93e20d5daa4a640fa9f7d9e932c869ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _menuEquipmentListView: {fileID: 2988731076915673364}
+--- !u!1001 &2435691288566326468
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6211493806772389741}
+    m_Modifications:
+    - target: {fileID: 628053437819968976, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: _itemObject
+      value: 
+      objectReference: {fileID: 2022546281581388950}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276298777196706043, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_Name
+      value: EquipList
+      objectReference: {fileID: 0}
+    - target: {fileID: 5538985958177478138, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 95683f48f62a545de9538bb0d1cdfbf2, type: 3}
+--- !u!224 &3493388872632589312 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1276298777196705988, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2435691288566326468}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2988731076915673364 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 628053437819968976, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2435691288566326468}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7884d1128ffce413c8701c5cb91119d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3493388873492431930 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1276298776076869886, guid: 95683f48f62a545de9538bb0d1cdfbf2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2435691288566326468}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6009764720124617176
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 3493388873492431930}
+    m_Modifications:
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139405, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
+        type: 3}
+      propertyPath: m_Name
+      value: MenuEquipView
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 578531183ce034498acce8f07c24c064, type: 3}
+--- !u!1 &2022546281581388950 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5726184038843139406, guid: 578531183ce034498acce8f07c24c064,
+    type: 3}
+  m_PrefabInstance: {fileID: 6009764720124617176}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab.meta
+++ b/Assets/App/Resources/Prefabs/Menu/EquipMenuControl.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c6c885c8bde124d6a9686896e6adedcc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab
@@ -1,5 +1,84 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8046450583553642852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2725053724961733108}
+  - component: {fileID: 8990159859372306447}
+  - component: {fileID: 3750909896101546625}
+  m_Layer: 5
+  m_Name: ActiveMark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2725053724961733108
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8046450583553642852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5726184038843139405}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 38.21}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8990159859372306447
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8046450583553642852}
+  m_CullTransparentMesh: 1
+--- !u!114 &3750909896101546625
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8046450583553642852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9433962, g: 0.7879681, b: 0.51174796, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 25
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u88C5\u5099\u4E2D"
 --- !u!114 &3472365430745811872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14,6 +93,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _titleText: {fileID: 5726184037027992513}
   _button: {fileID: 792089955302981671}
+  _buttonText: {fileID: 8835260427842559921}
+  _activeMark: {fileID: 8046450583553642852}
 --- !u!1001 &8707878935264690408
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -131,12 +212,23 @@ PrefabInstance:
       propertyPath: m_Name
       value: MenuEquipView
       objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616806, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4012680648489616804, guid: 1e38ac1b6de36429d92342ebcaba3486, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1e38ac1b6de36429d92342ebcaba3486, type: 3}
 --- !u!1 &5726184038843139406 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4012680648489616806, guid: 1e38ac1b6de36429d92342ebcaba3486,
+    type: 3}
+  m_PrefabInstance: {fileID: 8707878935264690408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5726184038843139405 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
     type: 3}
   m_PrefabInstance: {fileID: 8707878935264690408}
   m_PrefabAsset: {fileID: 0}
@@ -162,5 +254,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8835260427842559921 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 163747299305987929, guid: 1e38ac1b6de36429d92342ebcaba3486,
+    type: 3}
+  m_PrefabInstance: {fileID: 8707878935264690408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab
@@ -1,0 +1,166 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &3472365430745811872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5726184038843139406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cac2008848fad478aaee34251481f9f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _titleText: {fileID: 5726184037027992513}
+  _button: {fileID: 792089955302981671}
+--- !u!1001 &8707878935264690408
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616805, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012680648489616806, guid: 1e38ac1b6de36429d92342ebcaba3486,
+        type: 3}
+      propertyPath: m_Name
+      value: MenuEquipView
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4012680648489616804, guid: 1e38ac1b6de36429d92342ebcaba3486, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 1e38ac1b6de36429d92342ebcaba3486, type: 3}
+--- !u!1 &5726184038843139406 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4012680648489616806, guid: 1e38ac1b6de36429d92342ebcaba3486,
+    type: 3}
+  m_PrefabInstance: {fileID: 8707878935264690408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5726184037027992513 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4012680649358955305, guid: 1e38ac1b6de36429d92342ebcaba3486,
+    type: 3}
+  m_PrefabInstance: {fileID: 8707878935264690408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &792089955302981671 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8225411712190398671, guid: 1e38ac1b6de36429d92342ebcaba3486,
+    type: 3}
+  m_PrefabInstance: {fileID: 8707878935264690408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab.meta
+++ b/Assets/App/Resources/Prefabs/Menu/MenuEquipView.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 578531183ce034498acce8f07c24c064
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Resources/Prefabs/Menu/MenuItemView.prefab
+++ b/Assets/App/Resources/Prefabs/Menu/MenuItemView.prefab
@@ -408,7 +408,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 20, y: 0}
   m_SizeDelta: {x: 400, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &4012680649358955304

--- a/Assets/App/Scenes/Menu.unity
+++ b/Assets/App/Scenes/Menu.unity
@@ -570,6 +570,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &879586711 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7859694166149296445, guid: c6c885c8bde124d6a9686896e6adedcc,
+    type: 3}
+  m_PrefabInstance: {fileID: 4377029771098050515}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1035014565
 GameObject:
   m_ObjectHideFlags: 0
@@ -1216,6 +1222,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 96f8359427c9a42e188f5c862041a578, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _text: {fileID: 457215108}
 --- !u!1 &2106119296
 GameObject:
   m_ObjectHideFlags: 0
@@ -1362,6 +1369,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: EquipMenuControl
       objectReference: {fileID: 0}
+    - target: {fileID: 2988731076915673364, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: _itemObject
+      value: 
+      objectReference: {fileID: 879586711}
     - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
         type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/App/Scenes/Menu.unity
+++ b/Assets/App/Scenes/Menu.unity
@@ -311,7 +311,8 @@ MonoBehaviour:
   _needsProcessManager: 0
   _model: {fileID: 705245394}
   _view: {fileID: 1613319338}
-  _bagControl: {fileID: 1525037380}
+  _bagControl: {fileID: 4999761735360342761}
+  _equipControl: {fileID: 8439874960503434526}
 --- !u!4 &705245393
 Transform:
   m_ObjectHideFlags: 0
@@ -599,6 +600,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4999761735360342760}
+  - {fileID: 7678072043634346174}
   m_Father: {fileID: 1613319337}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -985,18 +987,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1351510141}
   m_CullTransparentMesh: 1
---- !u!114 &1525037380 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7405478066656933632, guid: 552bcfed4982e41cdb17c82bf1a8d845,
-    type: 3}
-  m_PrefabInstance: {fileID: 4999761735360342759}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f7b61c61a50749228ca0c19d889c8fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1613319333
 GameObject:
   m_ObjectHideFlags: 0
@@ -1360,6 +1350,125 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2106119296}
   m_CullTransparentMesh: 1
+--- !u!1001 &4377029771098050515
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1035014566}
+    m_Modifications:
+    - target: {fileID: 428726044966636739, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_Name
+      value: EquipMenuControl
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c6c885c8bde124d6a9686896e6adedcc, type: 3}
 --- !u!1001 &4999761735360342759
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1371,11 +1480,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: BagMenuControl
-      objectReference: {fileID: 0}
-    - target: {fileID: 3799418422841165895, guid: 552bcfed4982e41cdb17c82bf1a8d845,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623540542039002393, guid: 552bcfed4982e41cdb17c82bf1a8d845,
         type: 3}
@@ -1490,3 +1594,33 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4999761735360342759}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4999761735360342761 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 384646472144051875, guid: 552bcfed4982e41cdb17c82bf1a8d845,
+    type: 3}
+  m_PrefabInstance: {fileID: 4999761735360342759}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7b61c61a50749228ca0c19d889c8fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &7678072043634346174 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
+    type: 3}
+  m_PrefabInstance: {fileID: 4377029771098050515}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8439874960503434526 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5304713615719178957, guid: c6c885c8bde124d6a9686896e6adedcc,
+    type: 3}
+  m_PrefabInstance: {fileID: 4377029771098050515}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93e20d5daa4a640fa9f7d9e932c869ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/App/Scenes/Menu.unity
+++ b/Assets/App/Scenes/Menu.unity
@@ -570,12 +570,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &879586711 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7859694166149296445, guid: c6c885c8bde124d6a9686896e6adedcc,
-    type: 3}
-  m_PrefabInstance: {fileID: 4377029771098050515}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1035014565
 GameObject:
   m_ObjectHideFlags: 0
@@ -1369,11 +1363,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: EquipMenuControl
       objectReference: {fileID: 0}
-    - target: {fileID: 2988731076915673364, guid: c6c885c8bde124d6a9686896e6adedcc,
-        type: 3}
-      propertyPath: _itemObject
-      value: 
-      objectReference: {fileID: 879586711}
     - target: {fileID: 6211493806772389741, guid: c6c885c8bde124d6a9686896e6adedcc,
         type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/App/Scripts/Common/MasterData/Equipment.meta
+++ b/Assets/App/Scripts/Common/MasterData/Equipment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a91be848b0914e92b15e31ab7cbfb2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
@@ -39,7 +39,7 @@ namespace Ling.MasterData.Equipment
 
 		#region プロパティ
 
-		public abstract Const.Equipment.Type Type { get; }
+		public abstract Const.Equipment.Category Type { get; }
 
 		/// <summary>
 		/// アイテム名

--- a/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
@@ -34,6 +34,12 @@ namespace Ling.MasterData.Equipment
 		[SerializeField, FieldName("説明")]
 		private string _desc = default;
 
+		[SerializeField, FieldName("攻撃力")]
+		private int _attack = default;
+
+		[SerializeField, FieldName("防御力")]
+		private int _defense = default;
+
 		#endregion
 
 
@@ -50,6 +56,9 @@ namespace Ling.MasterData.Equipment
 		/// 詳細
 		/// </summary>
 		public string Desc => _desc;
+
+		public int Attack => _attack;
+		public int Defense => _defense;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs
@@ -1,0 +1,71 @@
+﻿//
+// EquipmentMaster.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+using Utility.Attribute;
+using Utility.MasterData;
+
+namespace Ling.MasterData.Equipment
+{
+	/// <summary>
+	/// 装備マスタの基本
+	/// </summary>
+	public abstract class EquipmentMaster : MasterDataBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField, FieldName("名前")]
+		private string _name = default;
+
+		[SerializeField, FieldName("説明")]
+		private string _desc = default;
+
+		#endregion
+
+
+		#region プロパティ
+
+		public abstract Const.Equipment.Type Type { get; }
+
+		/// <summary>
+		/// アイテム名
+		/// </summary>
+		public string Name => _name;
+
+		/// <summary>
+		/// 詳細
+		/// </summary>
+		public string Desc => _desc;
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/EquipmentMaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a31c4cbccc92c42e7967d426d7faff28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Equipment/ShieldMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/ShieldMaster.cs
@@ -1,0 +1,55 @@
+﻿//
+// ShieldMaster.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+using Utility.Attribute;
+
+namespace Ling.MasterData.Equipment
+{
+	/// <summary>
+	/// 盾マスタ
+	/// </summary>
+	[CreateAssetMenu(menuName = "MasterData/ShieldMaster", fileName = "ShieldMaster")]
+	public class ShieldMaster : EquipmentMaster
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		public override Const.Equipment.Type Type => Const.Equipment.Type.Shield;
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Equipment/ShieldMaster.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/ShieldMaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67db1a5cb1d514de8a2aca86ea3a16b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs
@@ -1,0 +1,55 @@
+﻿//
+// WeaponMaster.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+///
+
+using UnityEngine;
+using Utility.Attribute;
+
+namespace Ling.MasterData.Equipment
+{
+	/// <summary>
+	/// 武器マスタ
+	/// </summary>
+	[CreateAssetMenu(menuName = "MasterData/WeaponMaster", fileName = "WeaponMaster")]
+	public class WeaponMaster : EquipmentMaster
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		public override Const.Equipment.Type Type => Const.Equipment.Type.Weapon;
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs
@@ -33,7 +33,7 @@ namespace Ling.MasterData.Equipment
 
 		#region プロパティ
 
-		public override Const.Equipment.Type Type => Const.Equipment.Type.Weapon;
+		public override Const.Equipment.Category Type => Const.Equipment.Category.Weapon;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Equipment/WeaponMaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55aa7f4ae8e704aa2b65713d0212520a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/MasterManager.cs
+++ b/Assets/App/Scripts/Common/MasterData/MasterManager.cs
@@ -34,6 +34,7 @@ namespace Ling.MasterData
 		PlayerLvTableRepository PlayerLvTableRepository { get; }
 
 		ItemRepositoryContainer ItemRespositoryContainer { get; }
+		EquipRepositoryContainer EquipRepositoryContainer { get; }
 	}
 
 	/// <summary>
@@ -68,6 +69,7 @@ namespace Ling.MasterData
 		public BookRepository BookRepository => GetRepository<BookRepository>();
 		public FoodRepository FoodRepository => GetRepository<FoodRepository>();
 		public ItemRepositoryContainer ItemRespositoryContainer { get; } = new ItemRepositoryContainer();
+		public EquipRepositoryContainer EquipRepositoryContainer { get; } = new EquipRepositoryContainer();
 		public PlayerLvTableRepository PlayerLvTableRepository => GetRepository<PlayerLvTableRepository>();
 
 

--- a/Assets/App/Scripts/Common/MasterData/MasterManager.cs
+++ b/Assets/App/Scripts/Common/MasterData/MasterManager.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using Ling.MasterData.Chara;
 using Ling.MasterData.Stage;
 using Ling.MasterData.Item;
+using Ling.MasterData.Equipment;
 using Ling.MasterData.Repository;
 using Ling.MasterData.Repository.Item;
 using Ling.MasterData.Repository.Player;
@@ -69,9 +70,12 @@ namespace Ling.MasterData
 		public StageRepository StageRepository => GetRepository<StageRepository>();
 		public BookRepository BookRepository => GetRepository<BookRepository>();
 		public FoodRepository FoodRepository => GetRepository<FoodRepository>();
+		public PlayerLvTableRepository PlayerLvTableRepository => GetRepository<PlayerLvTableRepository>();
+		public WeaponRepository WeaponRepository => GetRepository<WeaponRepository>();
+		public ShieldRepository ShieldRepository => GetRepository<ShieldRepository>();
+
 		public ItemRepositoryContainer ItemRespositoryContainer { get; } = new ItemRepositoryContainer();
 		public EquipRepositoryContainer EquipRepositoryContainer { get; } = new EquipRepositoryContainer();
-		public PlayerLvTableRepository PlayerLvTableRepository => GetRepository<PlayerLvTableRepository>();
 
 
 		#endregion
@@ -91,11 +95,14 @@ namespace Ling.MasterData
 			AddLoadRepositoryTask<BookMaster, ItemMaster, BookRepository>("ItemBookMaster");
 			AddLoadRepositoryTask<FoodMaster, ItemMaster, FoodRepository>("ItemFoodMaster");
 			AddLoadRepositoryTask<LvTableMaster, PlayerLvTableRepository>("PlayerLvTableMaster");
+			AddLoadRepositoryTask<WeaponMaster, EquipmentMaster, WeaponRepository>("WeaponMaster");
+			AddLoadRepositoryTask<ShieldMaster, EquipmentMaster, ShieldRepository>("ShieldMaster");
 
 			// 非同期でTaskを実行し、すべての処理が終わるまで待機
 			await UniTask.WhenAll(_loadTasks);
 
 			ItemRespositoryContainer.Update(BookRepository, FoodRepository);
+			EquipRepositoryContainer.Update(WeaponRepository, ShieldRepository);
 
 			LoadFinished();
 		}

--- a/Assets/App/Scripts/Common/MasterData/MasterManager.cs
+++ b/Assets/App/Scripts/Common/MasterData/MasterManager.cs
@@ -13,6 +13,7 @@ using Ling.MasterData.Item;
 using Ling.MasterData.Repository;
 using Ling.MasterData.Repository.Item;
 using Ling.MasterData.Repository.Player;
+using Ling.MasterData.Repository.Equipment;
 using Cysharp.Threading.Tasks;
 using Cysharp.Threading.Tasks.Linq;
 using UniRx;

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment.meta
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0b263ef2d56346609ab14c938e4a8f6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/EquipRepositoryContainer.cs
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/EquipRepositoryContainer.cs
@@ -1,0 +1,60 @@
+﻿//
+// EquipRepositoryContainer.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using Ling.MasterData.Equipment;
+
+namespace Ling.MasterData.Repository.Equipment
+{
+	/// <summary>
+	/// 装備マスタコンテナ
+	/// </summary>
+	public class EquipRepositoryContainer : Utility.MasterData.MasterRepositoryContainer<Const.Equipment.Category, EquipmentMaster>
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+		public WeaponRepository Weapon => FindRepository<WeaponRepository>(Const.Equipment.Category.Weapon);
+		public ShieldRepository Shield => FindRepository<ShieldRepository>(Const.Equipment.Category.Shield);
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public void Update(WeaponRepository weapon, ShieldRepository shield)
+		{
+			AddRepository(Const.Equipment.Category.Weapon, weapon);
+			AddRepository(Const.Equipment.Category.Shield, shield);
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/EquipRepositoryContainer.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/EquipRepositoryContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eda6d11e68748412e80dcfb0f97eac98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/ShieldRepository.cs
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/ShieldRepository.cs
@@ -1,20 +1,18 @@
 ﻿//
-// ShieldMaster.cs
+// ShieldRepository.cs
 // ProductName Ling
 //
 // Created by toshiki sakamoto on 2021.05.05
 //
 
-using UnityEngine;
-using Utility.Attribute;
+using Ling.MasterData.Equipment;
 
-namespace Ling.MasterData.Equipment
+namespace Ling.MasterData.Repository.Equipment
 {
 	/// <summary>
-	/// 盾マスタ
+	/// 盾マスタリポジトリ
 	/// </summary>
-	[CreateAssetMenu(menuName = "MasterData/ShieldMaster", fileName = "ShieldMaster")]
-	public class ShieldMaster : EquipmentMaster
+	public class ShieldRepository : Utility.MasterData.InheritanceMasterRepository<EquipmentMaster, ShieldMaster>
 	{
 		#region 定数, class, enum
 
@@ -32,8 +30,6 @@ namespace Ling.MasterData.Equipment
 
 
 		#region プロパティ
-
-		public override Const.Equipment.Category Type => Const.Equipment.Category.Shield;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/ShieldRepository.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/ShieldRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c06338004a80843888cfd659f7756c54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/WeaponRepository.cs
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/WeaponRepository.cs
@@ -1,20 +1,18 @@
 ﻿//
-// ShieldMaster.cs
+// WeaponRepository.cs
 // ProductName Ling
 //
 // Created by toshiki sakamoto on 2021.05.05
 //
 
-using UnityEngine;
-using Utility.Attribute;
+using Ling.MasterData.Equipment;
 
-namespace Ling.MasterData.Equipment
+namespace Ling.MasterData.Repository.Equipment
 {
 	/// <summary>
-	/// 盾マスタ
+	/// 武器マスタ
 	/// </summary>
-	[CreateAssetMenu(menuName = "MasterData/ShieldMaster", fileName = "ShieldMaster")]
-	public class ShieldMaster : EquipmentMaster
+	public class WeaponRepository : Utility.MasterData.InheritanceMasterRepository<EquipmentMaster, WeaponMaster>
 	{
 		#region 定数, class, enum
 
@@ -32,8 +30,6 @@ namespace Ling.MasterData.Equipment
 
 
 		#region プロパティ
-
-		public override Const.Equipment.Category Type => Const.Equipment.Category.Shield;
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/MasterData/Repository/Equipment/WeaponRepository.cs.meta
+++ b/Assets/App/Scripts/Common/MasterData/Repository/Equipment/WeaponRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a05a0206b8a14bbfb579860c7b4851d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/Scene/Battle/BattleResult.cs
+++ b/Assets/App/Scripts/Common/Scene/Battle/BattleResult.cs
@@ -14,6 +14,13 @@ namespace Ling.Common.Scene.Battle
 	{
 		#region 定数, class, enum
 
+		// メニューシーンから戻ってきた時
+		public enum MenuCategory
+		{
+			UseItem,	// アイテム使用
+			Equip,		// アイテム装備
+		}
+
 		#endregion
 
 
@@ -29,10 +36,17 @@ namespace Ling.Common.Scene.Battle
 
 		#region プロパティ
 
+		public MenuCategory Menu { get; set; }
+
 		/// <summary>
 		/// 使用したアイテム情報
 		/// </summary>
 		public Common.Item.ItemEntity UseItemEntity { get; set; }
+
+		/// <summary>
+		/// 装備or外す
+		/// </summary>
+		public UserData.Equipment.EquipmentUserData EquipEntity { get; set; }
 
 		#endregion
 
@@ -48,7 +62,10 @@ namespace Ling.Common.Scene.Battle
 		/// アイテムを使用した時
 		/// </summary>
 		public static BattleResult CreateAtItemUse(Common.Item.ItemEntity itemEntity) =>
-			new BattleResult { UseItemEntity = itemEntity };
+			new BattleResult { Menu = MenuCategory.UseItem, UseItemEntity = itemEntity };
+
+		public static BattleResult CreateAtEquip(UserData.Equipment.EquipmentUserData entity) =>
+			new BattleResult { Menu = MenuCategory.Equip, EquipEntity = entity };
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/Scene/Menu/MenuDefine.cs
+++ b/Assets/App/Scripts/Common/Scene/Menu/MenuDefine.cs
@@ -39,9 +39,10 @@ namespace Ling.Common.Scene.Menu
 		{
 			switch (self)
 			{
-				case MenuDefine.Category.Bag: return "Bag";
-				case MenuDefine.Category.Shop: return "Shop";
-				case MenuDefine.Category.Setting: return "Setting";
+				case MenuDefine.Category.Bag: return "もちもの";
+				case MenuDefine.Category.Equip: return "装備";
+				case MenuDefine.Category.Shop: return "ショップ";
+				case MenuDefine.Category.Setting: return "設定";
 
 				default: return "None";
 			}

--- a/Assets/App/Scripts/Common/Scene/Menu/MenuDefine.cs
+++ b/Assets/App/Scripts/Common/Scene/Menu/MenuDefine.cs
@@ -26,7 +26,8 @@ namespace Ling.Common.Scene.Menu
 		/// </summary>
 		public enum Category
 		{
-			Bag,		// 持ち物
+			Bag,		// 持ち物(今はアイテムのみとする)
+			Equip,		// 装備一覧
 			Shop,		// ショップ:買う
 			Setting,	// 設定
 		}

--- a/Assets/App/Scripts/Common/UserData/Equipment.meta
+++ b/Assets/App/Scripts/Common/UserData/Equipment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2d56655d919f46b5b4d44c86f48b048
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -39,6 +39,8 @@ namespace Ling.UserData.Equipment
 
 		public int ID { get => _id; set => _id = value; }
 
+		public string Name => Master.Name;
+
 		public Const.Equipment.Category Category { get => _category; set => _category = value; }
 
 		public MasterData.Equipment.EquipmentMaster Master 

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -13,6 +13,7 @@ namespace Ling.UserData.Equipment
 	/// <summary>
 	/// 装備データ
 	/// </summary>
+	[System.Serializable]
 	public class EquipmentUserData : Utility.GameData.IGameDataBasic
 	{
 		#region 定数, class, enum
@@ -29,6 +30,7 @@ namespace Ling.UserData.Equipment
 
 		[SerializeField] private int _id;
 		[SerializeField] private Const.Equipment.Category _category;
+		[SerializeField] private bool _equipped = false;	// 装備中
 
 		private MasterData.Equipment.EquipmentMaster _master;
 
@@ -42,6 +44,8 @@ namespace Ling.UserData.Equipment
 		public string Name => Master.Name;
 
 		public Const.Equipment.Category Category { get => _category; set => _category = value; }
+
+		public bool Equipped => _equipped;
 
 		public MasterData.Equipment.EquipmentMaster Master 
 		{

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -48,7 +48,7 @@ namespace Ling.UserData.Equipment
 				if (_master != null) return _master;
 
 				var holder = Common.GameManager.Instance.MasterHolder;
-				_master = holder.ItemRespositoryContainer.Find(Category, _id);
+				_master = holder.EquipRepositoryContainer.Find(Category, _id);
 
 				return _master;
 			}

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -1,0 +1,58 @@
+﻿//
+// EquipmentUserData.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+
+namespace Ling.UserData.Equipment
+{
+	/// <summary>
+	/// 装備データ
+	/// </summary>
+	public class EquipmentUserData : Utility.GameData.IGameDataBasic
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField] private int _id;
+		[SerializeField] private Const.Equipment.Category _category;
+
+		#endregion
+
+
+		#region プロパティ
+
+		public int ID { get => _id; set => _id = value; }
+
+		public Const.Equipment.Category Category { get => _category; set => _category = value; }
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -70,6 +70,22 @@ namespace Ling.UserData.Equipment
 
 		#region public, protected 関数
 
+		/// <summary>
+		/// 装備を外す
+		/// </summary>
+		public void Detach()
+		{
+			_equipped = false;
+		}
+
+		/// <summary>
+		/// 装着
+		/// </summary>
+		public void Attach()
+		{
+			_equipped = true;
+		}
+
 		#endregion
 
 

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs
@@ -6,6 +6,7 @@
 //
 
 using UnityEngine;
+using Ling.MasterData.Skill;
 
 namespace Ling.UserData.Equipment
 {
@@ -29,6 +30,8 @@ namespace Ling.UserData.Equipment
 		[SerializeField] private int _id;
 		[SerializeField] private Const.Equipment.Category _category;
 
+		private MasterData.Equipment.EquipmentMaster _master;
+
 		#endregion
 
 
@@ -37,6 +40,19 @@ namespace Ling.UserData.Equipment
 		public int ID { get => _id; set => _id = value; }
 
 		public Const.Equipment.Category Category { get => _category; set => _category = value; }
+
+		public MasterData.Equipment.EquipmentMaster Master 
+		{
+			get 
+			{
+				if (_master != null) return _master;
+
+				var holder = Common.GameManager.Instance.MasterHolder;
+				_master = holder.ItemRespositoryContainer.Find(Category, _id);
+
+				return _master;
+			}
+		}
 
 		#endregion
 

--- a/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs.meta
+++ b/Assets/App/Scripts/Common/UserData/Equipment/EquipmentUserData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ce313f9811554ac8901dcaa3d4051a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
+++ b/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
@@ -1,0 +1,68 @@
+﻿//
+// EquipmentUserDataRepository.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using Ling.UserData.Equipment;
+
+namespace Ling.Common.UserData.Repository
+{
+	/// <summary>
+	/// 装備ユーザーデータ
+	/// </summary>
+	public class EquipmentUserDataRepository : Utility.UserData.UserDataRepository<EquipmentUserData>
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		#endregion
+
+
+		#region プロパティ
+
+#if DEBUG
+		protected override bool EnableDebugMode => true; // todo: 強制ON
+#endif
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+#if DEBUG
+		protected override void DebugAddFinished()
+		{
+			var entities = new EquipmentUserData[]
+				{
+					new EquipmentUserData { ID = 1, Category = Const.Equipment.Category.Weapon },
+					new EquipmentUserData { ID = 1, Category = Const.Equipment.Category.Shield },
+				};
+
+			Add(entities);
+		}
+#endif
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
+++ b/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
@@ -6,6 +6,10 @@
 //
 
 using Ling.UserData.Equipment;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using Ling;
 
 namespace Ling.UserData.Repository
 {
@@ -25,6 +29,9 @@ namespace Ling.UserData.Repository
 
 
 		#region private 変数
+
+		private IEnumerable<EquipmentUserData> _weapons;
+		private IEnumerable<EquipmentUserData> _shileds;
 
 		#endregion
 
@@ -58,10 +65,57 @@ namespace Ling.UserData.Repository
 		}
 #endif
 
+		/// <summary>
+		/// 引数のアイテムを装備させる
+		/// </summary>
+		public (EquipmentUserData detach, EquipmentUserData attach) Equip(EquipmentUserData target)
+		{
+			var equippedData = default(EquipmentUserData);
+
+			if (target.Category == Const.Equipment.Category.Weapon)
+			{
+				equippedData = GetEquippedWeapon();
+			}
+			else
+			{
+				equippedData = GetEquippedShield();
+			}
+
+			// 装備済みのアイテムであれば装備を外すだけ
+			// 装備しているものと違う場合、外す→装着を行う
+			equippedData?.Detach();
+
+			if (equippedData != target)
+			{
+				target.Attach();
+
+				return (equippedData, target);
+			}
+
+			// 装着はしなかった
+			return (equippedData, null);
+		}
+
+		/// <summary>
+		/// 装備済みの武器データを返す
+		/// </summary>
+		public EquipmentUserData GetEquippedWeapon() =>
+			_weapons.FirstOrDefault(entity => entity.Equipped);
+
+		public EquipmentUserData GetEquippedShield() =>
+			_shileds.FirstOrDefault(entity => entity.Equipped);
+
 		#endregion
 
 
 		#region private 関数
+
+		protected override void AddFinishedInternal()
+		{
+			// 武器と盾に分ける
+			_weapons = Entities.Where(entity => entity.Category == Const.Equipment.Category.Weapon);
+			_shileds = Entities.Where(entity => entity.Category == Const.Equipment.Category.Shield);
+		}
 
 		#endregion
 	}

--- a/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
+++ b/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs
@@ -7,7 +7,7 @@
 
 using Ling.UserData.Equipment;
 
-namespace Ling.Common.UserData.Repository
+namespace Ling.UserData.Repository
 {
 	/// <summary>
 	/// 装備ユーザーデータ

--- a/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs.meta
+++ b/Assets/App/Scripts/Common/UserData/Repository/EquipmentUserDataRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7b35f6575625430697b25f787428528
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Common/UserData/UserDataManager.cs
+++ b/Assets/App/Scripts/Common/UserData/UserDataManager.cs
@@ -14,6 +14,7 @@ using Cysharp.Threading.Tasks;
 using UniRx;
 
 using Ling.UserData.Item;
+using Ling.UserData.Equipment;
 using Ling.UserData.Repository;
 
 using Zenject;
@@ -26,6 +27,7 @@ namespace Ling.UserData
 	public interface IUserDataHolder
 	{
 		ItemUserDataRepository ItemRepository { get; }
+		EquipmentUserDataRepository EquipmentRepository { get; }
 	}
 
 	
@@ -53,6 +55,7 @@ namespace Ling.UserData
 		#region プロパティ
 
 		ItemUserDataRepository IUserDataHolder.ItemRepository => GetRepository<ItemUserDataRepository>();
+		EquipmentUserDataRepository IUserDataHolder.EquipmentRepository => GetRepository<EquipmentUserDataRepository>();
 
 		#endregion
 
@@ -67,6 +70,7 @@ namespace Ling.UserData
 		public async override UniTask LoadAll()
 		{
 			AddLoadRepositoryTask<ItemUserData, ItemUserDataRepository>("ItemUserData");
+			AddLoadRepositoryTask<EquipmentUserData, EquipmentUserDataRepository>("EquipmentUserData");
 
 			// 非同期でTaskを実行し、すべての処理が終わるまで待機
 			await UniTask.WhenAll(_loadTasks);

--- a/Assets/App/Scripts/Const/Equipment.cs
+++ b/Assets/App/Scripts/Const/Equipment.cs
@@ -1,0 +1,21 @@
+﻿//
+// Equipment.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+namespace Ling.Const
+{
+	/// <summary>
+	/// 装備
+	/// </summary>
+	public static class Equipment
+	{
+		public enum Type
+		{
+			Weapon, 	// 武器
+			Shield,		// 盾
+		}
+	}
+}

--- a/Assets/App/Scripts/Const/Equipment.cs
+++ b/Assets/App/Scripts/Const/Equipment.cs
@@ -12,7 +12,7 @@ namespace Ling.Const
 	/// </summary>
 	public static class Equipment
 	{
-		public enum Type
+		public enum Category
 		{
 			Weapon, 	// 武器
 			Shield,		// 盾

--- a/Assets/App/Scripts/Const/Equipment.cs.meta
+++ b/Assets/App/Scripts/Const/Equipment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37597ffaa1c3643efb695bed17947617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Const/ItemType.cs
+++ b/Assets/App/Scripts/Const/ItemType.cs
@@ -21,8 +21,8 @@ namespace Ling.Const
 
 			Food,   // 食べ物
 			Book,   // 本 (読むと効果が発揮するもの)
-			Weapon, // 武器
-			Shield, // 盾
+			//Weapon, // 武器
+			//Shield, // 盾
 		}
 
 		/// <summary>

--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -50,6 +50,7 @@ namespace Ling.Scenes.Battle
 		NextStage,
 		Adv,
 		UseItem,
+		Equip,	// 装備着脱
 	}
 
 	/// <summary>
@@ -170,6 +171,7 @@ namespace Ling.Scenes.Battle
 			RegistPhase<BattlePhaseExp>(Phase.Exp);
 			RegistPhase<BattlePhaseCharaMove>(Phase.Move);
 			RegistPhase<BattlePhaseUseItem>(Phase.UseItem);
+			RegistPhase<BattlePhaseEquip>(Phase.Equip);
 
 			ProcessContainer.Setup(_processManager, gameObject);
 
@@ -333,7 +335,8 @@ namespace Ling.Scenes.Battle
 				case BattleResult.MenuCategory.Equip:
 					if (result.EquipEntity != null)
 					{
-
+						var arg = new BattlePhaseEquip.Arg { Entity = result.EquipEntity };
+						_phase.ChangePhase(Phase.Equip, arg);
 					}
 					break;
 			}

--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -198,6 +198,9 @@ namespace Ling.Scenes.Battle
 					if (ev.unit == null || ev.opponent == null) return;
 					if (ev.unit == ev.opponent) return;
 
+					// プレイヤーが死んだ場合は何もしない
+					if (ev.opponent == _charaManager.Player) return;
+
 					// 獲得量
 					var exp = ev.opponent.Model.Exp;
 

--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -15,6 +15,7 @@ using Zenject;
 using Ling.MasterData.Repository;
 using Ling.Scenes.Battle.Phases;
 using Ling.Scenes.Battle.ProcessContainer;
+using Ling.Common.Scene.Battle;
 
 namespace Ling.Scenes.Battle
 {
@@ -248,17 +249,7 @@ namespace Ling.Scenes.Battle
 			switch (sceneID)
 			{
 				case SceneID.Menu:
-					// なにか使用したか
-					if (result?.UseItemEntity == null)
-					{
-						// 何も使用してないならプレイヤー行動に戻す
-						_phase.ChangePhase(Phase.PlayerAction);
-					}
-					else
-					{
-						var useItemArg = new BattlePhaseUseItem.Arg { Item = result.UseItemEntity };
-						_phase.ChangePhase(Phase.UseItem, useItemArg);
-					}
+					OnCamebackByMenu(result);
 					break;
 			}
 		}
@@ -324,6 +315,33 @@ namespace Ling.Scenes.Battle
 
 		#region private 関数
 
+		private void OnCamebackByMenu(BattleResult result)
+		{
+			if (result == null) return;
+
+			switch (result.Menu)
+			{
+				case BattleResult.MenuCategory.UseItem:
+					// なにか使用したか
+					if (result.UseItemEntity != null)
+					{
+						var useItemArg = new BattlePhaseUseItem.Arg { Item = result.UseItemEntity };
+						_phase.ChangePhase(Phase.UseItem, useItemArg);
+					}
+					break;
+
+				case BattleResult.MenuCategory.Equip:
+					if (result.EquipEntity != null)
+					{
+
+					}
+					break;
+			}
+
+
+			// 何も使用してないならプレイヤー行動に戻す
+			_phase.ChangePhase(Phase.PlayerAction);
+		}
 
 		#endregion
 

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs
@@ -1,0 +1,89 @@
+﻿//
+// BattlePhaseEquip.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.08
+//
+
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+using System.Threading;
+using Zenject;
+using Utility.Extensions;
+
+namespace Ling.Scenes.Battle.Phases
+{
+	/// <summary>
+	/// アイテム装備
+	/// </summary>
+	public class BattlePhaseEquip : BattlePhaseBase
+	{
+		#region 定数, class, enum
+
+		public class Arg : Utility.PhaseArgument
+		{
+			public UserData.Equipment.EquipmentUserData Entity;
+		}
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[Inject] private Chara.CharaManager _charaManager = default;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public override void PhaseStart()
+		{
+			// アイテムによって処理を変更する
+			var arg = Argument as Arg;
+
+/*
+			// スキル
+			var skill = arg.Item.Skill;
+			var player = _charaManager.Player;
+			var skillProcess = player.AddAttackProcess<Skill.SkillProcess>();
+			skillProcess.Setup(player, skill);
+
+			// キャラアクションに移動する
+			var process = new Process.ProcessCharaAction(player);
+			Scene.ProcessContainer.Add(ProcessType.PlayerSkill, process);
+
+			Change(Phase.PlayerSkill);*/
+		}
+
+		public override void PhaseUpdate()
+		{
+		}
+
+		public override void PhaseStop()
+		{
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs
@@ -10,6 +10,7 @@ using Cysharp.Threading.Tasks;
 using System.Threading;
 using Zenject;
 using Utility.Extensions;
+using Ling.UserData;
 
 namespace Ling.Scenes.Battle.Phases
 {
@@ -36,6 +37,7 @@ namespace Ling.Scenes.Battle.Phases
 		#region private 変数
 
 		[Inject] private Chara.CharaManager _charaManager = default;
+		[Inject] private IUserDataHolder _userDataHolder = default;
 
 		#endregion
 
@@ -71,6 +73,36 @@ namespace Ling.Scenes.Battle.Phases
 			Change(Phase.PlayerSkill);*/
 		}
 
+		public override async UniTask PhaseStartAsync(CancellationToken token)
+		{
+			var arg = Argument as Arg;
+			var battleManager = BattleManager.Instance;
+
+			// 装備処理を呼び出す
+			var equipRepository = _userDataHolder.EquipmentRepository;
+			var equipResult = equipRepository.Equip(arg.Entity);
+
+			// 外す処理から
+			if (equipResult.detach != null)
+			{
+				// todo: 仮
+				battleManager.ShowMessage($"{equipResult.detach.Name} を 外した");
+			}
+
+			// 装着
+			if (equipResult.attach != null)
+			{
+				// todo: 仮
+				battleManager.ShowMessage($"{equipResult.attach.Name} を 装着した");
+			}
+
+			// メッセージ終了まで待機
+			await battleManager.WaitMessageSending();
+
+			// 終わったら敵の思考に移動する
+			Change(Phase.EnemyTink);
+		}
+
 		public override void PhaseUpdate()
 		{
 		}
@@ -83,6 +115,7 @@ namespace Ling.Scenes.Battle.Phases
 
 
 		#region private 関数
+
 
 		#endregion
 	}

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseEquip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45608959faac045f3a6942d3a5af686c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs
@@ -64,10 +64,10 @@ namespace Ling.Scenes.Menu.Category
 			_entities = repository.Entities;
 			_menuEquipmentListView.Setup(_entities);
 
-			_menuEquipmentListView.OnClick = itemEntity => 
+			_menuEquipmentListView.OnClick = entity => 
 				{
 					// アイテムを使用したか装備したか
-					OnEquipped?.Invoke(itemEntity);
+					OnEquipped?.Invoke(entity);
 				};
 		}
 

--- a/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs
@@ -1,0 +1,91 @@
+﻿//
+// MenuCategoryEquip.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+using Zenject;
+using Ling.UserData;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Ling.Scenes.Menu.Category
+{
+	/// <summary>
+	/// 装備一覧
+	/// </summary>
+	public class MenuCategoryEquip : MenuCategoryBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[Inject] private IUserDataHolder _userDataHolder = default;
+
+		[SerializeField] private Panel.MenuEquipmentListView _menuEquipmentListView = default;
+
+		private List<UserData.Equipment.EquipmentUserData> _entities;
+
+		#endregion
+
+
+		#region プロパティ
+
+		/// <summary>
+		/// アイテムを使用した時
+		/// </summary>
+		public System.Action<UserData.Equipment.EquipmentUserData> OnEquipped { get; set; }
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public void Setup()
+		{
+			var repository = _userDataHolder.EquipmentRepository;
+
+			// アイテム一覧を表示する
+			_entities = repository.Entities;
+			_menuEquipmentListView.Setup(_entities);
+
+			_menuEquipmentListView.OnClick = itemEntity => 
+				{
+					// アイテムを使用したか装備したか
+					OnEquipped?.Invoke(itemEntity);
+				};
+		}
+
+
+		/// <summary>
+		/// アクティブ状態にする
+		/// </summary>
+		public override void Activate()
+		{
+			gameObject.SetActive(true);
+			_menuEquipmentListView.gameObject.SetActive(true);
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs.meta
+++ b/Assets/App/Scripts/Scenes/Menu/Category/MenuCategoryEquip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93e20d5daa4a640fa9f7d9e932c869ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Menu/MenuModel.cs
+++ b/Assets/App/Scripts/Scenes/Menu/MenuModel.cs
@@ -76,6 +76,7 @@ namespace Ling.Scenes.Menu
 			{
 				case MenuDefine.Group.Menu:
 					CategoryData.Add(new MenuCategoryData(MenuDefine.Category.Bag));
+					CategoryData.Add(new MenuCategoryData(MenuDefine.Category.Equip));
 					CategoryData.Add(new MenuCategoryData(MenuDefine.Category.Setting));
 					break;
 

--- a/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
+++ b/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
@@ -41,6 +41,7 @@ namespace Ling.Scenes.Menu
 
 		[Header("メニューカテゴリコントロール")]
 		[SerializeField] private Category.MenuCategoryBag _bagControl = default;
+		[SerializeField] private Category.MenuCategoryEquip _equipControl = default;
 
 		private List<Category.MenuCategoryBase> _categoryControls = new List<Category.MenuCategoryBase>();
 
@@ -161,6 +162,13 @@ namespace Ling.Scenes.Menu
 
 					// アイテムを使用した時
 					_bagControl.OnUseItem = itemEntity => UseItem(itemEntity);
+					break;
+
+				// 装備一覧
+				case MenuDefine.Category.Equip:
+					_equipControl.Setup();
+					_categoryControls.Add(_equipControl);
+
 					break;
 			}
 		}

--- a/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
+++ b/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
@@ -169,6 +169,9 @@ namespace Ling.Scenes.Menu
 					_equipControl.Setup();
 					_categoryControls.Add(_equipControl);
 
+					// 装備したことを伝える
+					_equipControl.OnEquipped = entity => Equip(entity);
+
 					break;
 			}
 		}
@@ -206,6 +209,18 @@ namespace Ling.Scenes.Menu
 
 			// シーンを戻る
 			var result = BattleResult.CreateAtItemUse(itemEntity);
+			_sceneManager.CloseSceneAsync(this, result).Forget();
+		}
+
+		/// <summary>
+		/// 装備した
+		/// </summary>
+		private void Equip(UserData.Equipment.EquipmentUserData entity)
+		{
+			Utility.Log.Print($"アイテムを装備or外す {entity.ID}, {entity.Name}");
+
+			// シーンを戻る
+			var result = BattleResult.CreateAtEquip(entity);
 			_sceneManager.CloseSceneAsync(this, result).Forget();
 		}
 

--- a/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
+++ b/Assets/App/Scripts/Scenes/Menu/MenuScene.cs
@@ -182,6 +182,10 @@ namespace Ling.Scenes.Menu
 				case MenuDefine.Category.Bag:
 					_bagControl.Activate();
 					break;
+
+				case MenuDefine.Category.Equip:
+					_equipControl.Activate();
+					break;
 			}
 		}
 

--- a/Assets/App/Scripts/Scenes/Menu/MenuTitleItem.cs
+++ b/Assets/App/Scripts/Scenes/Menu/MenuTitleItem.cs
@@ -29,6 +29,8 @@ namespace Ling.Scenes.Menu
 
 		#region private 変数
 
+		[SerializeField] private Text _text = default;
+
 		private Toggle _toggle = default;
 
 		#endregion
@@ -52,6 +54,7 @@ namespace Ling.Scenes.Menu
 		{
 			TitleData = titleData;
 			_toggle.isOn = titleData.IsOn;
+			_text.text = titleData.Title;
 		}
 
 		#endregion

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentListView.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentListView.cs
@@ -1,0 +1,95 @@
+﻿//
+// MenuEquipmentListView.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+using Utility.UI;
+using System.Collections.Generic;
+using System.Linq;
+using UniRx;
+
+namespace Ling.Scenes.Menu.Panel
+{
+	/// <summary>
+	/// 装備
+	/// </summary>
+	public class MenuEquipmentListView : MonoBehaviour,
+		RecyclableScrollView.IContentDataProvider
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField] private RecyclableScrollView _scrollView = default;
+		[SerializeField] private GameObject _itemObject = default;
+
+		private List<UserData.Equipment.EquipmentUserData> _entities;
+		private float _itemSize;
+
+		#endregion
+
+
+		#region プロパティ
+
+		int RecyclableScrollView.IContentDataProvider.DataCount => _entities.Count;
+
+		public System.Action<UserData.Equipment.EquipmentUserData> OnClick { get; set; }
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public void Setup(IEnumerable<UserData.Equipment.EquipmentUserData> entities)
+		{
+			_entities = entities.ToList();
+			_itemSize = _itemObject.GetComponent<RectTransform>().sizeDelta.y;
+
+			_scrollView.Initialize(this);
+		}
+
+		float RecyclableScrollView.IContentDataProvider.GetItemSize(int index) =>
+			_itemSize;
+
+		GameObject RecyclableScrollView.IContentDataProvider.GetItemObj(int index) =>
+			_itemObject;
+
+		void RecyclableScrollView.IContentDataProvider.ScrollItemUpdate(int index, GameObject obj, bool init)
+		{
+			var entity = _entities[index];
+
+			var item = obj.GetComponent<MenuEquipmentView>();
+			item.Setup(entity);
+
+			if (init)
+			{
+				item.OnClick
+					.Subscribe(_ => OnClick?.Invoke(item.Entity));
+			}
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+
+
+		#region MonoBegaviour
+
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentListView.cs.meta
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentListView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7884d1128ffce413c8701c5cb91119d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
@@ -1,0 +1,71 @@
+﻿//
+// MenuEquipmentView.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2021.05.05
+//
+
+using UnityEngine;
+using UnityEngine.UI;
+using System;
+using UniRx;
+
+namespace Ling.Scenes.Menu.Panel
+{
+	/// <summary>
+	/// 装備
+	/// </summary>
+	public class MenuEquipmentView : MonoBehaviour 
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public 変数
+
+		#endregion
+
+
+		#region private 変数
+
+		[SerializeField] private Text _titleText = default;
+		[SerializeField] private Button _button = default;
+
+		private UserData.Equipment.EquipmentUserData _entity;
+
+		#endregion
+
+
+		#region プロパティ
+
+		public UserData.Equipment.EquipmentUserData Entity => _entity;
+
+		public IObservable<Unit> OnClick => _button.OnClickAsObservable();
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public void Setup(UserData.Equipment.EquipmentUserData entity)
+		{
+			_entity = entity;
+
+			// 名前の設定
+			_titleText.text = _entity.Name;
+		}
+
+		#endregion
+
+
+		#region private 関数
+
+		#endregion
+
+
+		#region MonoBegaviour
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
@@ -32,6 +32,7 @@ namespace Ling.Scenes.Menu.Panel
 		[SerializeField] private Text _titleText = default;
 		[SerializeField] private Button _button = default;
 		[SerializeField] private Text _buttonText = default;
+		[SerializeField] private GameObject _activeMark = default;
 
 		private UserData.Equipment.EquipmentUserData _entity;
 
@@ -56,10 +57,18 @@ namespace Ling.Scenes.Menu.Panel
 			// 名前の設定
 			_titleText.text = _entity.Name;
 
-			// 「装備」に名前を変える
-			_buttonText.text = "装備";
+			if (entity.Equipped)
+			{
+				// 現在装備中のものには「装備」ではなく、「外す」にする
+				_buttonText.text = "外す";
+			}
+			else
+			{
+				// 「装備」に名前を変える
+				_buttonText.text = "装着";
+			}
 
-			// 現在装備中のものには「装備」ボタンは出さない
+			_activeMark.SetActive(entity.Equipped);
 		}
 
 		#endregion

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs
@@ -31,6 +31,7 @@ namespace Ling.Scenes.Menu.Panel
 
 		[SerializeField] private Text _titleText = default;
 		[SerializeField] private Button _button = default;
+		[SerializeField] private Text _buttonText = default;
 
 		private UserData.Equipment.EquipmentUserData _entity;
 
@@ -54,6 +55,11 @@ namespace Ling.Scenes.Menu.Panel
 
 			// 名前の設定
 			_titleText.text = _entity.Name;
+
+			// 「装備」に名前を変える
+			_buttonText.text = "装備";
+
+			// 現在装備中のものには「装備」ボタンは出さない
 		}
 
 		#endregion

--- a/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs.meta
+++ b/Assets/App/Scripts/Scenes/Menu/Panel/MenuEquipmentView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cac2008848fad478aaee34251481f9f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/App/Scripts/Utility/GameData/GameDataRepository.cs
+++ b/Assets/App/Scripts/Utility/GameData/GameDataRepository.cs
@@ -126,6 +126,7 @@ namespace Utility.GameData
 				DebugAddFinished();
 			}
 #endif
+			AddFinishedInternal();
 		}
 
 #if DEBUG
@@ -136,6 +137,8 @@ namespace Utility.GameData
 
 
 		#region private 関数
+
+		protected virtual void AddFinishedInternal() {}
 
 		#endregion
 	}

--- a/Assets/AssetBundles/MasterData/Equipment.meta
+++ b/Assets/AssetBundles/MasterData/Equipment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 492f53155458646569f61de3386ed21d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AssetBundles/MasterData/Equipment/Shield.meta
+++ b/Assets/AssetBundles/MasterData/Equipment/Shield.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7871491884b04e128f59ba8dbe109a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AssetBundles/MasterData/Equipment/Shield/WoodShieldMaster.asset
+++ b/Assets/AssetBundles/MasterData/Equipment/Shield/WoodShieldMaster.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db1a5cb1d514de8a2aca86ea3a16b8, type: 3}
+  m_Name: WoodShieldMaster
+  m_EditorClassIdentifier: 
+  _id: 1
+  _name: "\u6728\u306E\u76FE"
+  _desc: "\u6728\u3067\u4F5C\u3089\u308C\u305F\u76FE"
+  _attack: 0
+  _defense: 5

--- a/Assets/AssetBundles/MasterData/Equipment/Shield/WoodShieldMaster.asset.meta
+++ b/Assets/AssetBundles/MasterData/Equipment/Shield/WoodShieldMaster.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5f2842a81517409abf94df42e356f4d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AssetBundles/MasterData/Equipment/Weapon.meta
+++ b/Assets/AssetBundles/MasterData/Equipment/Weapon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f48942022755c428cb4e394de2e5e915
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AssetBundles/MasterData/Equipment/Weapon/SwordMaster.asset
+++ b/Assets/AssetBundles/MasterData/Equipment/Weapon/SwordMaster.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55aa7f4ae8e704aa2b65713d0212520a, type: 3}
+  m_Name: SwordMaster
+  m_EditorClassIdentifier: 
+  _id: 1
+  _name: "\u305F\u3060\u306E\u5263"
+  _desc: "\u3088\u304F\u3042\u308B\u5263"
+  _attack: 5
+  _defense: 0

--- a/Assets/AssetBundles/MasterData/Equipment/Weapon/SwordMaster.asset.meta
+++ b/Assets/AssetBundles/MasterData/Equipment/Weapon/SwordMaster.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c07293e4b9e4e44af87fc2b182342d8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
UserDataの作成と、Menuにアイテム一覧とは別にスクリプト作成することにした（共通化するかどうかはまた検討

シレンではアイテムと装備は同じ管理としているが、あえて別にしてみる
**メリット**
- 装備のみ別管理することで装備はアイテムとしての管理ではなく、装備としての管理ができる
- シレンはアイテム管理が難しい印象なので別にすることでレベルデザインがしやすいのではないか

**デメリット**
- シレンのようにツボに装備を入れて管理することができなくなる（敵に投げてダメージを与えたり
- 装備タブ開くのが面倒？