### PR TITLE
敵行動処理が一度しか走らないようになっていたので修正

### DIFF
--- a/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
+++ b/Assets/App/Scripts/Scenes/Battle/BattleScene.cs
@@ -37,7 +37,7 @@ namespace Ling.Scenes.Battle
 		// Player
 		PlayerActionStart,
 		PlayerActionProcess,
-		PlayerActionEnd,
+		PlayerProcessEnd,
 
 		// Enemy
 		EnemyAction,
@@ -188,6 +188,7 @@ namespace Ling.Scenes.Battle
 			RegistPhase<BattlePhasePlayerActionStart>(Phase.PlayerActionStart);
 			RegistPhase<BattlePhasePlayerAction>(Phase.PlayerActionProcess);
 			RegistPhase<BattlePhaseItemGet>(Phase.ItemGet);
+			RegistPhase<BattlePhasePlayerProcessEnd>(Phase.PlayerProcessEnd);
 
 			RegistPhase<BattlePhaseAdv>(Phase.Adv);
 			RegistPhase<BattlePhaseNextStage>(Phase.NextStage);

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseCharaProcessEnd.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseCharaProcessEnd.cs
@@ -53,6 +53,12 @@ namespace Ling.Scenes.Battle.Phases
 
 		public override void PhaseStart()
 		{
+			// CharaActionが残っているときは終わるまで繰り返す
+			if (Scene.ProcessContainer.Exists(ProcessType.Action))
+			{
+				// todo: Executerに戻す処理入れたほうが良ければ入れる
+			}
+
 			// 今の所何もすることないのでプレイヤー行動開始時に戻す
 			// 足元確認とか次に入れるほうが良さそう
 

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseExp.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhaseExp.cs
@@ -33,7 +33,7 @@ namespace Ling.Scenes.Battle.Phases
 			/// 終了後、再度キャラの行動処理に移す
 			/// </summary>
 			public static Arg CreateAtCharaProcessExecuter() =>
-				new Arg { NextPhase = Phase.CharaProcessEnd };
+				new Arg { NextPhase = Phase.CharaProcessExecute };
 
 			public Utility.PhaseArgument GetNextArgument()
 			{

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerProcessEnd.cs
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerProcessEnd.cs
@@ -1,0 +1,69 @@
+﻿//
+// BattlePhaseCharaProcessEnd.cs
+// ProductName Ling
+//
+// Created by toshiki sakamoto on 2020.08.23
+//
+
+using Ling.Const;
+using Ling.Map.TileDataMapExtensions;
+using Zenject;
+
+namespace Ling.Scenes.Battle.Phases
+{
+	/// <summary>
+	/// プレイヤーのプロセス終了処理
+	/// → 今はプレイヤーの行動が終わったら敵思考に回してるけどその途中になにかはさみたい時に使う
+	/// </summary>
+	public class BattlePhasePlayerProcessEnd : BattlePhaseBase
+	{
+		#region 定数, class, enum
+
+		#endregion
+
+
+		#region public, protected 変数
+
+		#endregion
+
+
+		#region private 変数
+
+
+		[Inject] private Chara.CharaManager _charaManager;
+		[Inject] private Map.MapManager _mapManager;
+
+		#endregion
+
+
+		#region プロパティ
+
+		#endregion
+
+
+		#region コンストラクタ, デストラクタ
+
+		#endregion
+
+
+		#region public, protected 関数
+
+		public override void PhaseInit()
+		{
+		}
+
+		public override void PhaseStart()
+		{
+
+		}
+
+
+		#endregion
+
+
+		#region private 関数
+
+
+		#endregion
+	}
+}

--- a/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerProcessEnd.cs.meta
+++ b/Assets/App/Scripts/Scenes/Battle/Phases/BattlePhasePlayerProcessEnd.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd03d306b92c244f59db6757cfa82424
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
敵２体に攻撃されても一度しか処理しないようになっていた
行動→行動終了→経験値処理　が終わった後再度行動に処理を回すように修正